### PR TITLE
Bugfix  shots in incorrect directions

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -185,13 +185,13 @@ update action game =
             (Shot.initShot game.ship.x game.ship.y)
 
           vxy ( x', y' ) =
-            (,) (round (toFloat x' - toFloat absPositionX))  (round (toFloat y' - toFloat absPositionY))
+            (,) (x' - absPositionX) (absPositionY - y')
 
           absPositionX =
             (game.width // 2) + (round (game.ship.x))
 
           absPositionY =
-            (game.height // 2) + (round (game.ship.y))
+            (game.height // 2) - (round (game.ship.y))
 
       in
         { game | shots = (shot (vxy ( x, y ))) :: game.shots }
@@ -220,9 +220,9 @@ view game =
       (round h)
       [ rect w h
           |> filled (rgb 0 0 0)
+      , toForm (shotsView game)
       , Ship.view game.ship
       , toForm (asteroidsView game)
-      , toForm (shotsView game)
       , toForm
           (container
             (round w)

--- a/src/Shot/Shot.elm
+++ b/src/Shot/Shot.elm
@@ -24,7 +24,7 @@ initShot x' y' (vx', vy') =
   , y = y'
   , vx = toFloat vx'
   , vy = toFloat vy'
-  , radius = 1.0
+  , radius = 2.0
   }
 
 
@@ -44,10 +44,19 @@ update action shot =
       shot
 
     UpdateShot ->
-      { shot
-        | x = shot.x + 0.03 * shot.vx
-        , y = shot.y + 0.03 * shot.vy
-      }
+      let
+          tempShot =
+            { shot
+            | vx = shot.vx + (shot.vx * 0.3)
+            , vy = shot.vy + (shot.vy * 0.3)
+          }
+      in
+        { shot
+          | x = shot.x + 0.003 * tempShot.vx
+          , y = shot.y + 0.003 * tempShot.vy
+          , vx = tempShot.vx
+          , vy = tempShot.vy
+        }
 
 
 

--- a/src/Shot/Shot.elm
+++ b/src/Shot/Shot.elm
@@ -72,3 +72,4 @@ view shot =
     ngon 4 shot.radius
       |> filled (rgb 255 0 255)
       |> move position
+      |> rotate (shot.y * 30)


### PR DESCRIPTION
# What it does:
- Fixes shot direction to the correct direction based on the position of the ship and where the mouse is clicking.
  - Makes all shots accelerate off the screen
# Why it does it:
- Shooting in the wrong direction isn't the expected behaviour
# Related issues:
- Closes #3 #7
# What was learned:

Window (Bottom, Left)
Elements (Center, Center)
Mouse (Top, Left)
